### PR TITLE
Allow place chests and hoppers on the top of the pipe.

### DIFF
--- a/src/main/java/de/robotricker/transportpipes/listener/DuctListener.java
+++ b/src/main/java/de/robotricker/transportpipes/listener/DuctListener.java
@@ -373,9 +373,9 @@ public class DuctListener implements Listener {
                             BlockPlaceEvent event = new BlockPlaceEvent(placeBlock, placeBlock.getState(), clickedDuct.getBlockLoc().toBlock(placeBlock.getWorld()), interaction.item, interaction.p, true, interaction.hand);
                             Bukkit.getPluginManager().callEvent(event);
                             if (!event.isCancelled()) {
-
                                 if (!placeBlock.getType().isOccluding() && !Tag.SLABS.isTagged(placeBlock.getType()) && !Tag.STAIRS.isTagged(placeBlock.getType())
                                         && !Tag.IMPERMEABLE.isTagged(placeBlock.getType()) && placeBlock.getType() != Material.GLOWSTONE &&
+                                        !WorldUtils.isContainerBlock(placeBlock.getType()) &&
                                         placeBlock.getRelative(BlockFace.DOWN).getType().isAir()) {
                                     placeBlock.setBlockData(oldBlockData);
                                 }

--- a/src/main/java/de/robotricker/transportpipes/listener/TPContainerListener.java
+++ b/src/main/java/de/robotricker/transportpipes/listener/TPContainerListener.java
@@ -103,21 +103,12 @@ public class TPContainerListener implements Listener {
 
         BlockLocation blockLoc = new BlockLocation(block.getLocation());
         if (add) {
-
             if (pipeManager.getContainerAtLoc(block.getLocation()) == null) {
                 TransportPipesContainer container = createContainerFromBlock(block);
                 pipeManager.getContainers(block.getWorld()).put(blockLoc, container);
 
                 // only update the neighbor pipes if this updateContainerBlock method call is because of a chunk load that was not issued inside the onEnable method
-                if (updateNeighborPipes) {
-                    for (TPDirection dir : TPDirection.values()) {
-                        Duct duct = globalDuctManager.getDuctAtLoc(block.getWorld(), blockLoc.getNeighbor(dir));
-                        if (duct instanceof Pipe) {
-                            globalDuctManager.updateDuctConnections(duct);
-                            globalDuctManager.updateDuctInRenderSystems(duct, true);
-                        }
-                    }
-                }
+                doUpdateNeighborPipes(block, updateNeighborPipes, blockLoc);
 
                 transportPipes.runTaskSync(() -> {
                     //checks for double chest neighbor and updates the neighbors TransportPipesContainer if present
@@ -136,20 +127,23 @@ public class TPContainerListener implements Listener {
             }
 
         } else {
-
             TransportPipesContainer container = pipeManager.getContainerAtLoc(block.getLocation());
             if (container != null) {
                 pipeManager.getContainers(block.getWorld()).remove(blockLoc);
 
                 // only update the neighbor pipes if this updateContainerBlock method call is because of a chunk load that was not issued inside the onEnable method
-                if (updateNeighborPipes) {
-                    for (TPDirection dir : TPDirection.values()) {
-                        Duct duct = globalDuctManager.getDuctAtLoc(block.getWorld(), blockLoc.getNeighbor(dir));
-                        if (duct instanceof Pipe) {
-                            globalDuctManager.updateDuctConnections(duct);
-                            globalDuctManager.updateDuctInRenderSystems(duct, true);
-                        }
-                    }
+                doUpdateNeighborPipes(block, updateNeighborPipes, blockLoc);
+            }
+        }
+    }
+
+    private void doUpdateNeighborPipes(Block block, boolean updateNeighborPipes, BlockLocation blockLoc) {
+        if (updateNeighborPipes) {
+            for (TPDirection dir : TPDirection.values()) {
+                Duct duct = globalDuctManager.getDuctAtLoc(block.getWorld(), blockLoc.getNeighbor(dir));
+                if (duct instanceof Pipe) {
+                    globalDuctManager.updateDuctConnections(duct);
+                    globalDuctManager.updateDuctInRenderSystems(duct, true);
                 }
             }
         }


### PR DESCRIPTION
There was a bug that make it impossible to place container that is not occluding on the pipe. It would create an invalid "container" that eats every item that tries to enter the "container". This commit fixes the bug mentioned above.