### PR TITLE
Compatibility with LWCEntityLocking

### DIFF
--- a/src/main/java/de/robotricker/transportpipes/utils/LWCUtils.java
+++ b/src/main/java/de/robotricker/transportpipes/utils/LWCUtils.java
@@ -30,7 +30,7 @@ public class LWCUtils extends JavaModule {
 
     @Override
     public void onPostRegistration(LWCProtectionRegistrationPostEvent e) {
-        if (e.getProtection().getType() == Protection.Type.PUBLIC) {
+        if (e.getProtection().getType() == Protection.Type.PUBLIC || e.getProtection().getBlock() == null) {
             return;
         }
         boolean destroyedAtLeastOneDuct = false;


### PR DESCRIPTION
Some LWC implementations allow entity locking and will return null on Protection.getBlock() (if it is a protection for an entity), so I suggest to check if it is null and ignore that protection in this case to avoid a NPE

See this bug report: https://github.com/Brokkonaut/LWCEntityLocking/issues/5#issuecomment-1146879064