### PR TITLE
Sends EntityEquipment packet synchronously (Fixes #31)

### DIFF
--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/protocol/ProtocolService.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/protocol/ProtocolService.java
@@ -110,9 +110,7 @@ public class ProtocolService {
                 entityEquipmentContainer.getSlotStackPairLists().write(0, itemList);
             }
 
-            transportPipes.runTaskAsync(() -> {
-                protocolManager.sendServerPacket(player, entityEquipmentContainer);
-            }, 1L);
+            protocolManager.sendServerPacket(player, entityEquipmentContainer);
 
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Fixes https://github.com/BlackBeltPanda/Transport-Pipes/issues/31

After facing this issue for a while, I started studying Transport Pipes and trying to understand how this issue happened.

Using spectator mode, I was able to see that the armorstands were still there, but with no item to be shown. This desync might be caused because of high MSPT peaks that stands for a while.

This has been tested on 1.19.3 (Purpur b1888) in production for three days with high MSPT peaks and over 60 players. I haven't faced this issue anymore. Hope everyone who was facing it can also see improvements.

Sending it synchronously also didn't impact performance at all.