### PR TITLE
Fix player memory leak and tpipes tps

### DIFF
--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/PlayerSettingsService.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/PlayerSettingsService.java
@@ -27,5 +27,9 @@ public class PlayerSettingsService {
         }
         return cachedSettingsConfs.get(p);
     }
+    
+    public void clearSettingsConf(Player p) {
+    	cachedSettingsConfs.remove(p);
+    }
 
 }

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/commands/TPCommand.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/commands/TPCommand.java
@@ -5,6 +5,7 @@ import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import de.robotricker.transportpipes.ThreadService;
 import de.robotricker.transportpipes.duct.Duct;
+import de.robotricker.transportpipes.duct.pipe.Pipe;
 import de.robotricker.transportpipes.duct.manager.GlobalDuctManager;
 import de.robotricker.transportpipes.inventory.CreativeInventory;
 import de.robotricker.transportpipes.inventory.PlayerSettingsInventory;
@@ -61,8 +62,9 @@ public class TPCommand extends BaseCommand {
             Map<BlockLocation, Duct> ductMap = globalDuctManager.getDucts(world);
             for (Duct duct : ductMap.values()) {
                 if (duct.getDuctType().getBaseDuctType().is("Pipe")) {
+                	Pipe pipe = (Pipe) duct;
                     worldPipes++;
-                    worldItems += 0;
+                    worldItems += pipe.getItems().size();
                 }
             }
             cs.sendMessage(MessageUtils.formatColoredMsg("&6" + world.getName() + ": &e" + worldPipes + " &6" + "pipes, &e" + worldItems + " &6items"));

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/commands/TPCommand.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/commands/TPCommand.java
@@ -62,9 +62,8 @@ public class TPCommand extends BaseCommand {
             Map<BlockLocation, Duct> ductMap = globalDuctManager.getDucts(world);
             for (Duct duct : ductMap.values()) {
                 if (duct.getDuctType().getBaseDuctType().is("Pipe")) {
-                	Pipe pipe = (Pipe) duct;
                     worldPipes++;
-                    worldItems += pipe.getItems().size();
+                    worldItems += ((Pipe) duct).getItems().size();
                 }
             }
             cs.sendMessage(MessageUtils.formatColoredMsg("&6" + world.getName() + ": &e" + worldPipes + " &6" + "pipes, &e" + worldItems + " &6items"));

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/duct/manager/GlobalDuctManager.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/duct/manager/GlobalDuctManager.java
@@ -71,6 +71,10 @@ public class GlobalDuctManager {
     public Set<Duct> getPlayerDucts(Player player) {
         return playerDucts.computeIfAbsent(player, p -> ConcurrentHashMap.newKeySet());
     }
+    
+    public void clearPlayerDucts(Player player) {
+    	playerDucts.remove(player);
+    }
 
     public RenderSystem getPlayerRenderSystem(Player player, BaseDuctType<? extends Duct> baseDuctType) {
         PlayerSettingsConf conf = playerSettingsService.getOrCreateSettingsConf(player);

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/duct/manager/PipeManager.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/duct/manager/PipeManager.java
@@ -223,6 +223,10 @@ public class PipeManager extends DuctManager<Pipe> {
     public Set<PipeItem> getPlayerPipeItems(Player player) {
         return playerItems.computeIfAbsent(player, p -> ConcurrentHashMap.newKeySet());
     }
+    
+    public void clearPlayerPipeItems(Player player) {
+    	playerItems.remove(player);
+    }
 
     public void spawnPipeItem(PipeItem pipeItem) {
         List<Player> playerList = WorldUtils.getPlayerList(pipeItem.getWorld());

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/listener/PlayerListener.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/listener/PlayerListener.java
@@ -42,7 +42,7 @@ public class PlayerListener implements Listener {
 
     @EventHandler
     public void onQuit(PlayerQuitEvent e) {
-        globalDuctManager.getPlayerDucts(e.getPlayer()).clear();
+        globalDuctManager.clearPlayerDucts(e.getPlayer());
         ((PipeManager) (DuctManager<? extends Duct>) ductRegister.baseDuctTypeOf("pipe").getDuctManager()).getPlayerPipeItems(e.getPlayer()).clear();
     }
 

--- a/transportpipes-core/src/main/java/de/robotricker/transportpipes/listener/PlayerListener.java
+++ b/transportpipes-core/src/main/java/de/robotricker/transportpipes/listener/PlayerListener.java
@@ -1,5 +1,6 @@
 package de.robotricker.transportpipes.listener;
 
+import de.robotricker.transportpipes.PlayerSettingsService;
 import de.robotricker.transportpipes.config.GeneralConf;
 import de.robotricker.transportpipes.duct.Duct;
 import de.robotricker.transportpipes.duct.DuctRegister;
@@ -39,11 +40,15 @@ public class PlayerListener implements Listener {
 
     @Inject
     private GeneralConf generalConf;
+    
+    @Inject
+    private PlayerSettingsService playerSettingsService;
 
     @EventHandler
     public void onQuit(PlayerQuitEvent e) {
         globalDuctManager.clearPlayerDucts(e.getPlayer());
-        ((PipeManager) (DuctManager<? extends Duct>) ductRegister.baseDuctTypeOf("pipe").getDuctManager()).getPlayerPipeItems(e.getPlayer()).clear();
+        ((PipeManager) (DuctManager<? extends Duct>) ductRegister.baseDuctTypeOf("pipe").getDuctManager()).clearPlayerPipeItems(e.getPlayer());
+        playerSettingsService.clearSettingsConf(e.getPlayer());
     }
 
     @EventHandler


### PR DESCRIPTION
This fixes a memory leak with Player instances being left behind after a player leaves.
When a player quits the server it was clearing their set of ducts but it was leaving the player key in the map, with no values associated. Now it should remove their entire entry.
I also changed the /tpipes tps command a bit, before it would always show 0 items, now it shows how many items are currently flowing.

Edit: There might be another similar issue [here](https://github.com/BlackBeltPanda/Transport-Pipes/blob/MultiModule/transportpipes-core/src/main/java/de/robotricker/transportpipes/PlayerSettingsService.java#L18) since that map is also never cleared. I will need to run my server for a longer time to check if there's more Player instances left behind.

Edit2: Yes, it was leaking there as well, I made it remove that entry on quit, everything seems to work well now.
If you need me to change anything let me know.